### PR TITLE
#238 - iframe height and width now auto adjust

### DIFF
--- a/omod/src/main/webapp/fragments/symptomManagement.gsp
+++ b/omod/src/main/webapp/fragments/symptomManagement.gsp
@@ -20,5 +20,9 @@
 </style>
 
 <div id="content" class="container">
-    <iframe id="portal" src="${SymptomManagementPortalUrl}"></iframe>
+    <script>
+        function resize_iframe_height(obj) { obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px'; }
+    </script>
+    <!-- note: onload triggers after every time the url of the iframe changes; so, when height of iframe content changes so will the iframe when `onload="resize_iframe_height(this)"` -->
+    <iframe id="portal" src="${SymptomManagementPortalUrl}" frameborder="0" scrolling="no" onload="resize_iframe_height(this)" style = 'width:100%; max-width:1000px;' />
 </div>


### PR DESCRIPTION
#238 solved by an onload height adjuster on the iframe and setting the initial width of the iframe to be large enough to display the full contents.  